### PR TITLE
Add obfuscation support: data encryption, memory syscalls, forwarded …

### DIFF
--- a/riscvm/encrypt.py
+++ b/riscvm/encrypt.py
@@ -1,4 +1,5 @@
 import json
+import os
 import re
 import sys
 import argparse
@@ -59,6 +60,21 @@ def get_functions(sections, link_base):
         'address': int(s['vma'], 16) - link_base,
         'vma': int(s['vma'], 16),
     } for s in symbols if s['align'] == '1' and s['size'] != '0']
+
+def get_data_section(sections, link_base):
+    """Returns the offset and size of the .data section relative to the binary start."""
+    data_section = sections.get(".data", None)
+    if data_section is None:
+        return None
+    vma = int(data_section['vma'], 16)
+    size = int(data_section['size'], 16)
+    if size == 0:
+        return None
+    return {
+        'address': vma - link_base,
+        'size': size,
+        'vma': vma,
+    }
 
 def tetra_twist(data: bytes) -> int:
     """
@@ -138,10 +154,11 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("input", help="Input RISC-V binary")
     parser.add_argument("--shuffle", "-s", help="Shuffle the operands", action="store_true", default=False)
-    parser.add_argument("--encrypt", "-e", help="Encrypt Binary", action="store_true", default=False)
+    parser.add_argument("--encrypt", "-e", help="Encrypt code section", action="store_true", default=False)
+    parser.add_argument("--encrypt-data", "-ed", help="Encrypt data section", action="store_true", default=False)
     parser.add_argument("--map", "-m", help="Input map file", required=True)
     parser.add_argument("--output", "-o", help="Output binary file", required=True)
-    parser.add_argument("--key", "-k", help="Encryption key (hex, int)", default="0xDEADBEEF")
+    parser.add_argument("--key", "-k", help="Encryption key (hex, int, or 'random')", default="random")
     parser.add_argument("--shuffle-map", "-sm", help="Shuffle map file")
     parser.add_argument("--opcodes-map", "-om", help="Opcodes map file")
 
@@ -153,12 +170,17 @@ def main():
     opcodes_json: str = args.opcodes_map
     shuffle: bool = args.shuffle
     encrypt: bool = args.encrypt
+    encrypt_data: bool = args.encrypt_data
 
-    try:
-        key = int(args.key, 0)
-    except:
-        print("Invalid key specified, must be a hex or int value")
-        sys.exit(1)
+    if args.key == "random":
+        key = int.from_bytes(os.urandom(4), 'little')
+        print(f"Generated random encryption key: {hex(key)}")
+    else:
+        try:
+            key = int(args.key, 0)
+        except:
+            print("Invalid key specified, must be a hex or int value, or 'random'")
+            sys.exit(1)
 
     if key < 0 or key > 0xFFFFFFFF:
         print("Invalid key specified, must be a 32-bit value")
@@ -221,6 +243,34 @@ def main():
                 dword = dword ^ transform(offset, key)
             binary[offset:offset+4] = struct.pack("<I", dword)
 
+    # Encrypt the data section if requested
+    if encrypt_data and encrypt:
+        data_section = get_data_section(sections, link_base)
+        if data_section is not None:
+            print(f"Encrypting data section at {hex(data_section['vma'])} with size {hex(data_section['size'])}")
+            # Encrypt in 4-byte chunks, pad the last chunk if needed
+            data_offset = data_section['address']
+            data_size = data_section['size']
+            for i in range(0, data_size - (data_size % 4), 4):
+                offset = data_offset + i
+                dword, = struct.unpack("<I", binary[offset:offset+4])
+                dword = dword ^ transform(offset, key)
+                binary[offset:offset+4] = struct.pack("<I", dword)
+            # Handle remaining bytes (if data size is not 4-byte aligned)
+            remainder = data_size % 4
+            if remainder > 0:
+                offset = data_offset + data_size - remainder
+                pad_bytes = binary[offset:offset+remainder] + b'\x00' * (4 - remainder)
+                dword, = struct.unpack("<I", pad_bytes)
+                dword = dword ^ transform(offset, key)
+                encrypted = struct.pack("<I", dword)[:remainder]
+                binary[offset:offset+remainder] = encrypted
+        else:
+            print("Warning: --encrypt-data specified but no .data section found")
+    elif encrypt_data and not encrypt:
+        print("Warning: --encrypt-data requires --encrypt to be enabled")
+        sys.exit(1)
+
     # Walk and verify the relocations
     rela_offset = binary.rfind(b"RELA")
     if rela_offset == -1:
@@ -241,6 +291,8 @@ def main():
         features |= 1
     if shuffle:
         features |= 2
+    if encrypt_data:
+        features |= 4
     binary += b"FEAT"
     binary += struct.pack("<BI", features, key)
 

--- a/riscvm/lib/crt0.c
+++ b/riscvm/lib/crt0.c
@@ -1,5 +1,6 @@
 static void exit(int exit_code);
 static void riscvm_relocs();
+static void riscvm_decrypt_data();
 void        riscvm_imports() __attribute__((weak));
 static void riscvm_init_arrays();
 extern int __attribute((noinline)) main();
@@ -8,6 +9,7 @@ extern int __attribute((noinline)) main();
 void _start()
 {
     riscvm_relocs();
+    riscvm_decrypt_data();
     riscvm_imports();
     riscvm_init_arrays();
     exit(main());
@@ -60,6 +62,83 @@ static __attribute((noinline)) void riscvm_relocs()
         {
             asm volatile("ebreak");
         }
+    }
+}
+
+extern uint8_t __data_start[];
+extern uint8_t __data_end[];
+
+static __attribute((noinline)) uint32_t riscvm_tetra_twist(uint32_t input)
+{
+    uint32_t prime1 = 0x9E3779B1;
+    input ^= input >> 15;
+    input *= prime1;
+    input ^= input >> 12;
+    input *= prime1;
+    input ^= input >> 4;
+    input *= prime1;
+    input ^= input >> 16;
+    return input;
+}
+
+static __attribute((noinline)) void riscvm_decrypt_data()
+{
+    // Check if data encryption feature flag is set in the FEAT section
+    // The FEAT section is at the end of the binary (after relocations)
+    // We look for the data_encrypted bit (bit 2) in the features byte
+    // If not set, this is a no-op
+    uintptr_t data_start = (uintptr_t)__data_start;
+    uintptr_t data_end = (uintptr_t)__data_end;
+    uintptr_t data_size = data_end - data_start;
+
+    if (data_size == 0)
+        return;
+
+    // The encryption key is stored in the FEAT section which is parsed by the host.
+    // For data decryption in the guest, the host passes the key and data_encrypted flag
+    // via a register or we read it from the FEAT trailer appended after relocations.
+    // We scan backwards from __relocs_start to find the FEAT magic.
+    uint8_t* feat_scan = __relocs_start;
+    // Walk past the relocation entries to find FEAT
+    if (*(uint32_t*)feat_scan == 'ALER')
+    {
+        feat_scan += 4; // skip RELA magic
+        while (*feat_scan != 0)
+            feat_scan += 13; // skip relocation entries (1+4+8 bytes each)
+        feat_scan += 1; // skip null terminator
+    }
+
+    if (*(uint32_t*)feat_scan != 'TAEF')
+        return; // No FEAT section found
+
+    uint8_t features = feat_scan[4];
+    if (!(features & 4)) // bit 2 = data_encrypted
+        return;
+
+    uint32_t key = *(uint32_t*)(feat_scan + 5);
+    uintptr_t load_base = (uintptr_t)__base;
+
+    // Decrypt in 4-byte chunks
+    uintptr_t aligned_size = data_size - (data_size % 4);
+    for (uintptr_t i = 0; i < aligned_size; i += 4)
+    {
+        uintptr_t offset = (data_start - load_base) + i;
+        uint32_t* ptr = (uint32_t*)(data_start + i);
+        uint32_t xor_key = riscvm_tetra_twist(key + (uint32_t)offset);
+        *ptr ^= xor_key;
+    }
+    // Handle remaining bytes
+    uintptr_t remainder = data_size % 4;
+    if (remainder > 0)
+    {
+        uintptr_t offset = (data_start - load_base) + aligned_size;
+        uint32_t tmp = 0;
+        for (uintptr_t j = 0; j < remainder; j++)
+            ((uint8_t*)&tmp)[j] = ((uint8_t*)(data_start + aligned_size))[j];
+        uint32_t xor_key = riscvm_tetra_twist(key + (uint32_t)offset);
+        tmp ^= xor_key;
+        for (uintptr_t j = 0; j < remainder; j++)
+            ((uint8_t*)(data_start + aligned_size))[j] = ((uint8_t*)&tmp)[j];
     }
 }
 
@@ -344,6 +423,42 @@ typedef struct _IMAGE_NT_HEADERS
 } IMAGE_NT_HEADERS;
 #pragma pack(pop)
 
+static uintptr_t riscvm_resolve_forwarded_export(const char* forward_str)
+{
+    // Forwarded export format: "DLL.FunctionName"
+    // Find the dot separator
+    const char* dot = forward_str;
+    while (*dot != '\0' && *dot != '.')
+        dot++;
+    if (*dot != '.')
+        return 0;
+
+    // Build the DLL name with ".dll" suffix for hash lookup
+    // We need a temporary buffer: copy the module name and append ".dll"
+    char dll_name[256];
+    uintptr_t name_len = (uintptr_t)(dot - forward_str);
+    if (name_len + 5 > sizeof(dll_name)) // +5 for ".dll\0"
+        return 0;
+
+    for (uintptr_t i = 0; i < name_len; i++)
+        dll_name[i] = forward_str[i];
+    dll_name[name_len]     = '.';
+    dll_name[name_len + 1] = 'd';
+    dll_name[name_len + 2] = 'l';
+    dll_name[name_len + 3] = 'l';
+    dll_name[name_len + 4] = '\0';
+
+    uint32_t module_hash = hash_x65599(dll_name, false);
+    uintptr_t module_base = riscvm_resolve_dll(module_hash);
+    if (!module_base)
+        return 0;
+
+    // Resolve the function name from the target module
+    const char* func_name = dot + 1;
+    uint32_t func_hash = hash_x65599(func_name, true);
+    return riscvm_resolve_import(module_base, func_hash);
+}
+
 uintptr_t riscvm_resolve_import(uintptr_t image, uint32_t export_hash)
 {
     IMAGE_DOS_HEADER*       dos_header      = (IMAGE_DOS_HEADER*)image;
@@ -359,12 +474,14 @@ uintptr_t riscvm_resolve_import(uintptr_t image, uint32_t export_hash)
     {
         char*     name = (char*)(image + names[i]);
         uintptr_t func = (uintptr_t)(image + funcs[ords[i]]);
-        // Ignore forwarded exports (TODO: handle properly?)
-        if (func >= (uintptr_t)export_dir && func < (uintptr_t)export_dir + export_dir_size)
-            continue;
-        uint32_t hash = hash_x65599(name, true);
+        uint32_t  hash = hash_x65599(name, true);
         if (hash == export_hash)
         {
+            // Check if this is a forwarded export
+            if (func >= (uintptr_t)export_dir && func < (uintptr_t)export_dir + export_dir_size)
+            {
+                return riscvm_resolve_forwarded_export((const char*)func);
+            }
             return func;
         }
     }

--- a/riscvm/lib/linker.ld
+++ b/riscvm/lib/linker.ld
@@ -14,11 +14,13 @@ SECTIONS
     }
 
     .data : {
+        __data_start = .;
         *(.rodata)
         *(.rodata.*)
         *(.data)
         *(.data.*)
         *(.eh_frame)
+        __data_end = .;
     }
 
     .init : {

--- a/riscvm/lib/syscalls.hpp
+++ b/riscvm/lib/syscalls.hpp
@@ -6,15 +6,17 @@ enum class e_syscall : uint32_t
     exit  = 10000,
     abort = 10001,
 
-    // malloc    = 10002,
-    // calloc    = 10003,
-    // realloc   = 10004,
-    // free      = 10005,
+    malloc  = 10002,
+    calloc  = 10003,
+    realloc = 10004,
+    free    = 10005,
 
     memcpy  = 10006,
     memset  = 10007,
     memmove = 10008,
     memcmp  = 10009,
+    strlen  = 10010,
+    strncmp = 10011,
 
     print_wstring = 10100,
     print_string = 10101,
@@ -134,6 +136,36 @@ ALWAYS_INLINE inline void* sys_memmove(void* vdest, const void* vsrc, uint64_t s
 ALWAYS_INLINE inline int sys_memcmp(const void* vdest, const void* vsrc, uint64_t size)
 {
     return syscall(e_syscall::memcmp, (long)vdest, (long)vsrc, (long)size);
+}
+
+ALWAYS_INLINE inline uint64_t sys_strlen(const char* str)
+{
+    return syscall(e_syscall::strlen, (long)str);
+}
+
+ALWAYS_INLINE inline int sys_strncmp(const char* s1, const char* s2, uint64_t n)
+{
+    return syscall(e_syscall::strncmp, (long)s1, (long)s2, (long)n);
+}
+
+ALWAYS_INLINE inline void* sys_malloc(uint64_t size)
+{
+    return (void*)(uintptr_t)syscall(e_syscall::malloc, (long)size);
+}
+
+ALWAYS_INLINE inline void* sys_calloc(uint64_t num, uint64_t size)
+{
+    return (void*)(uintptr_t)syscall(e_syscall::calloc, (long)num, (long)size);
+}
+
+ALWAYS_INLINE inline void* sys_realloc(void* ptr, uint64_t size)
+{
+    return (void*)(uintptr_t)syscall(e_syscall::realloc, (long)ptr, (long)size);
+}
+
+ALWAYS_INLINE inline void sys_free(void* ptr)
+{
+    syscall(e_syscall::free, (long)ptr);
 }
 
 ALWAYS_INLINE inline void sys_exit(long status)

--- a/riscvm/main.cpp
+++ b/riscvm/main.cpp
@@ -2,6 +2,11 @@
 #include <cstddef>
 #include <cstdlib>
 
+#ifndef _WIN32
+#include <strings.h>
+#define _stricmp strcasecmp
+#endif
+
 #include "riscvm.h"
 
 int main(int argc, char** argv)
@@ -16,11 +21,27 @@ int main(int argc, char** argv)
     riscvm_loadfile(machine, argv[1]);
 
 #ifdef _DEBUG
-    g_trace = argc > 2 && _stricmp(argv[2], "--trace") == 0;
+    g_trace = false;
+    const char* trace_file = "trace.txt";
+    for (int i = 2; i < argc; i++)
+    {
+        if (_stricmp(argv[i], "--trace") == 0)
+        {
+            g_trace = true;
+        }
+        else if (_stricmp(argv[i], "--trace-file") == 0 && i + 1 < argc)
+        {
+            trace_file = argv[++i];
+        }
+    }
     if (g_trace)
     {
-        // TODO: allow custom trace file location/name
-        machine->trace = fopen("trace.txt", "w");
+        machine->trace = fopen(trace_file, "w");
+        if (!machine->trace)
+        {
+            log("failed to open trace file: %s\n", trace_file);
+            return EXIT_FAILURE;
+        }
     }
 #endif // _DEBUG
 

--- a/riscvm/riscvm.cpp
+++ b/riscvm/riscvm.cpp
@@ -61,8 +61,9 @@ void riscvm_loadfile(riscvm_ptr self, const char* filename)
         uint32_t magic;
         struct
         {
-            bool encrypted : 1;
-            bool shuffled  : 1;
+            bool encrypted      : 1;
+            bool shuffled       : 1;
+            bool data_encrypted : 1;
         };
         uint32_t key;
     };
@@ -169,6 +170,37 @@ ALWAYS_INLINE static bool riscvm_handle_syscall(riscvm_ptr self, uint64_t code, 
         return false;
     }
 
+    case 10002: // malloc
+    {
+        size_t size = (size_t)reg_read(reg_a0);
+        result      = (uint64_t)malloc(size);
+        break;
+    }
+
+    case 10003: // calloc
+    {
+        size_t num  = (size_t)reg_read(reg_a0);
+        size_t size = (size_t)reg_read(reg_a1);
+        result      = (uint64_t)calloc(num, size);
+        break;
+    }
+
+    case 10004: // realloc
+    {
+        void*  ptr  = riscvm_getptr(self, reg_read(reg_a0));
+        size_t size = (size_t)reg_read(reg_a1);
+        result      = (uint64_t)realloc(ptr, size);
+        break;
+    }
+
+    case 10005: // free
+    {
+        void* ptr = riscvm_getptr(self, reg_read(reg_a0));
+        free(ptr);
+        result = 0;
+        break;
+    }
+
     case 10006: // memcpy
     {
         void* src  = riscvm_getptr(self, reg_read(reg_a0));
@@ -200,6 +232,21 @@ ALWAYS_INLINE static bool riscvm_handle_syscall(riscvm_ptr self, uint64_t code, 
         void* src1 = riscvm_getptr(self, reg_read(reg_a0));
         void* src2 = riscvm_getptr(self, reg_read(reg_a1));
         result     = (uint64_t)memcmp(src1, src2, (size_t)reg_read(reg_a2));
+        break;
+    }
+
+    case 10010: // strlen
+    {
+        char* str = (char*)riscvm_getptr(self, reg_read(reg_a0));
+        result    = (uint64_t)strlen(str);
+        break;
+    }
+
+    case 10011: // strncmp
+    {
+        char* s1 = (char*)riscvm_getptr(self, reg_read(reg_a0));
+        char* s2 = (char*)riscvm_getptr(self, reg_read(reg_a1));
+        result   = (uint64_t)(int64_t)strncmp(s1, s2, (size_t)reg_read(reg_a2));
         break;
     }
 

--- a/riscvm/riscvm.h
+++ b/riscvm/riscvm.h
@@ -279,4 +279,9 @@ ALWAYS_INLINE inline int32_t bit_signer(uint32_t field, uint32_t size)
 }
 
 void riscvm_loadfile(riscvm_ptr self, const char* filename);
+
+#ifdef _WIN32
 extern "C" __declspec(dllexport) void riscvm_run(riscvm_ptr self);
+#else
+extern "C" void riscvm_run(riscvm_ptr self);
+#endif

--- a/riscvm/tests.cpp
+++ b/riscvm/tests.cpp
@@ -1,4 +1,6 @@
 #include <cstddef>
+#include <cstdlib>
+#include <cstring>
 #include <memory>
 #include <vector>
 


### PR DESCRIPTION
…exports

- Implement malloc/calloc/realloc/free syscalls (previously commented out) in both the VM interpreter and the guest-side CRT library
- Add strlen and strncmp utility syscalls for string operations
- Implement data section encryption (--encrypt-data flag in encrypt.py) with matching decryption in the CRT startup code (riscvm_decrypt_data)
- Add __data_start/__data_end linker symbols for data section boundaries
- Generate random encryption keys by default instead of 0xDEADBEEF
- Implement forwarded export resolution in crt0.c (was a TODO) by parsing "DLL.FunctionName" forwarding strings and recursively resolving
- Add --trace-file CLI argument for custom trace output path (was a TODO)
- Fix cross-platform build: guard __declspec(dllexport), add _stricmp compat
- Fix missing includes in tests.cpp for non-MSVC compilers

https://claude.ai/code/session_019SSBRN8LwqxKEvXW14XQDy